### PR TITLE
Update Join-Uri.ps1

### DIFF
--- a/IO/Join-Uri.ps1
+++ b/IO/Join-Uri.ps1
@@ -7,7 +7,7 @@ function Join-Uri
         [uri]$uri, 
         [Parameter(ParameterSetName="Uri", Mandatory=$true, Position=1)]
         [string]$childPath)
-    $combinedPath = [system.io.path]::Combine($uri.AbsoluteUri, $childPath)
-    $combinedPath = $combinedPath.Replace('\', '/')
+    $combinedPath = [system.io.path]::Combine($uri.AbsoluteUri, $childPath.trim('/').trim('\'))
+    $combinedPath = $combinedPath.Replace('\', '/').replace('/?', '?')
     return New-Object uri $combinedPath
 }


### PR DESCRIPTION
removes extra slashes from childPath and removes the last slash before the query string 
the following examples would fail without the edits provided:
Example1 Join-Uri -uri "https://domain.com/testing/" -childPath "/test1data/"
Example2 Join-Uri -uri "https://domain.com/testing/ -childPath "?testdata=datum"